### PR TITLE
refactored so that a featured screenshot comes in on index

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -15,17 +15,22 @@ class Api::ApiController < ApplicationController
 
   private
 
-  def render_service(outcome, included: [], is_collection: false)
+  def render_service(outcome, included: [], is_collection: false, serializer: nil)
     if outcome.valid?
-      render_service_success_json(outcome, included, is_collection)
+      render_service_success_json(outcome, included, is_collection, serializer)
     else
       render_service_failure_json(outcome)
     end
   end
 
-  def render_service_success_json(outcome, included, is_collection)
+  def render_service_success_json(outcome, included, is_collection, serializer)
     data = outcome.result
-    json = JSONAPI::Serializer.serialize(data, include: included, is_collection: is_collection)
+    options = {}
+    options[:is_collection] = is_collection
+    options[:include] = included
+    options[:serializer] = serializer
+    json = JSONAPI::Serializer.serialize(data, options)
+
     render json: json, status: 200
   end
 

--- a/app/controllers/api/projects_controller.rb
+++ b/app/controllers/api/projects_controller.rb
@@ -9,14 +9,13 @@ class Api::ProjectsController < Api::ApiController
 
   def index
     outcome = ProjectService::Index.run
-    included = %w{color_set languages devices}
-    render_service(outcome, included: included, is_collection: true)
+    render_service(outcome, is_collection: true, serializer: ProjectsSerializer)
   end
 
   def show
     outcome = ProjectService::Show.run(id: params[:id])
     included = %w{color_set languages devices devices.screenshot}
-    render_service(outcome, included: included, is_collection: false)
+    render_service(outcome, included: included)
   end
 
   private

--- a/app/serializers/project_serializer.rb
+++ b/app/serializers/project_serializer.rb
@@ -16,11 +16,6 @@ class ProjectSerializer < BaseSerializer
   has_many :languages
   has_many :devices
 
-  attribute :featured_screenshot do
-    featured_device = object.devices.find_by(featured: true)
-    featured_device.screenshot.image.url if featured_device
-  end
-
   def format_name(attribute_name)
     attribute_name.to_s.underscore
   end

--- a/app/serializers/projects_serializer.rb
+++ b/app/serializers/projects_serializer.rb
@@ -1,0 +1,21 @@
+class ProjectsSerializer < ProjectSerializer
+  attribute :header_image do
+    nil
+  end
+
+  attribute :featured_screenshot do
+    featured_device = object.devices.find_by(featured: true)
+    title = nil
+    url = nil
+
+    if featured_device
+      title = featured_device.title
+      url = featured_device.screenshot.image.url
+    end
+
+    {
+      device: title,
+      image: url
+    }
+  end
+end

--- a/spec/requests/api/projects/index_spec.rb
+++ b/spec/requests/api/projects/index_spec.rb
@@ -21,7 +21,7 @@ describe "Project endpoints" do
       SmarfDoc.skip
       subject
 
-      featured_screenshot = project.devices.find_by(featured: true).screenshot.image.url
+      featured_device = project.devices.find_by(featured: true)
       expect(response_json[:data]).to include(
         id: project.id.to_s,
         type: "projects",
@@ -34,46 +34,29 @@ describe "Project endpoints" do
           closing_body: project[:closing_body],
           date_deployed: project[:date_deployed].as_json,
           featured: project[:featured],
-          header_image: project.header_image.url,
-          featured_screenshot: featured_screenshot
+          header_image: nil,
+          featured_screenshot: {
+            device: featured_device.title,
+            image: featured_device.screenshot.image.url
+          }
         },
         links: {
           self: project_link
         },
         relationships: {
           color_set: {
-            data: {
-              type: "color-sets",
-              id: color_set[:id].to_s,
-            },
             links: {
               self: "#{project_link}/relationships/color_set",
               related: "#{project_link}/color_set"
             }
           },
           languages: {
-            data: [
-              {
-                type: "languages",
-                id: languages.first.id.to_s,
-              },
-              {
-                type: "languages",
-                id: languages.last.id.to_s,
-              }
-            ],
             links: {
               self: "#{project_link}/relationships/languages",
               related: "#{project_link}/languages"
             }
           },
           devices: {
-            data: [
-              {
-                type: "devices",
-                id: devices.first.id.to_s,
-              }
-            ],
             links: {
               self: "#{project_link}/relationships/devices",
               related: "#{project_link}/devices"
@@ -87,76 +70,7 @@ describe "Project endpoints" do
       SmarfDoc.skip
       subject
 
-      expect(response_json[:included]).to include(
-        {
-          type: "color-sets",
-          id: color_set.id.to_s,
-          attributes: {
-            background: color_set[:background],
-            button: color_set[:button],
-            circle: color_set[:circle]
-          },
-          links: {
-            self: "/color-sets/#{color_set.id}"
-          }
-        },
-        {
-          type: "languages",
-          id: languages.first.id.to_s,
-          attributes: {
-            title: languages.first[:title],
-          },
-          links: {
-            self: "/languages/#{languages.first.id}"
-          }
-        },
-        {
-          type: "languages",
-          id: languages.last.id.to_s,
-          attributes: {
-            title: languages.last[:title],
-          },
-          links: {
-            self: "/languages/#{languages.last.id}"
-          }
-        },
-        {
-          type: "devices",
-          id: devices.first.id.to_s,
-          attributes: {
-            title: devices.first[:title],
-          },
-          links: {
-            self: "/devices/#{devices.first.id}"
-          },
-          relationships: {
-            screenshot: {
-              links: {
-                self: "/devices/#{devices.first.id}/relationships/screenshot",
-                related: "/devices/#{devices.first.id}/screenshot"
-              }
-            }
-          }
-        },
-        {
-          type: "devices",
-          id: devices.last.id.to_s,
-          attributes: {
-            title: devices.last[:title],
-          },
-          links: {
-            self: "/devices/#{devices.last.id}"
-          },
-          relationships: {
-            screenshot: {
-              links: {
-                self: "/devices/#{devices.last.id}/relationships/screenshot",
-                related: "/devices/#{devices.last.id}/screenshot"
-              }
-            }
-          }
-        }
-      )
+      expect(response_json[:included]).to eq([])
     end
 
     it "returns 5 projects" do

--- a/spec/requests/api/projects/show_spec.rb
+++ b/spec/requests/api/projects/show_spec.rb
@@ -34,8 +34,7 @@ describe "Project endpoints" do
           closing_body: project[:closing_body],
           date_deployed: project[:date_deployed].as_json,
           featured: project[:featured],
-          header_image: project.header_image.url,
-          featured_screenshot: featured_screenshot
+          header_image: project.header_image.url
         },
         links: {
           self: project_link


### PR DESCRIPTION
This was to optimize future performance. I didn't want a bunch of images loading on `/`. So I made a separate serializer that captures the one image I'll need on `/`.